### PR TITLE
fix: import_Maya_nParticles_cache HDA — code review fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,8 @@ dmypy.json
 !HDAs/export_Maya_nParticles_cache.hda/**
 !HDAs/export_Maya_geoCache.hda
 !HDAs/export_Maya_geoCache.hda/**
+!HDAs/import_Maya_nParticles_cache.hda
+!HDAs/import_Maya_nParticles_cache.hda/**
 !HDAs/README.md
 
 # HDA backups

--- a/HDAs/README.md
+++ b/HDAs/README.md
@@ -1,6 +1,6 @@
 # HDAs
 
-Houdini Digital Assets for Maya cache export.
+Houdini Digital Assets for Maya cache import and export.
 
 ---
 
@@ -150,3 +150,41 @@ left untouched.
 
 Use **Cache > Geometry Cache > Attach Existing Cache** and select the `.xml` file.
 Do **not** use File > Import — it will not create the cache connections.
+
+---
+
+## import_Maya_nParticles_cache.hda
+
+Reads a Maya **nParticles cache** (`.xml` + `.mc` / `.mcx` files) frame by frame
+and reconstructs the particle geometry as Houdini points.
+
+> **nParticles only.**  This HDA reads caches from Maya's **nParticles** system
+> (Nucleus solver).  It is **not** compatible with caches from the legacy Maya
+> **particle** object.
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| Python Module Path | Path to `nCache.py` |
+| nParticle Cache File | Path to the Maya cache `.xml` descriptor file |
+
+### Output Attributes
+
+The following point attributes are created when the corresponding channel is
+present in the cache:
+
+| Attribute | Type | Source channel |
+|-----------|------|----------------|
+| `P` | vector | `*_position` |
+| `id` | int | `*_id` |
+| *(others)* | float or vector | all remaining scalar / vector channels |
+
+Channels whose array length does not match the particle count at the current
+frame are silently skipped.
+
+### Per-frame Cooking
+
+The Python SOP inside this HDA cooks once per frame change.  For interactive
+playback over a slow network path, consider copying the `.mc` files to a local
+disk first.

--- a/HDAs/import_Maya_nParticles_cache.hda/INDEX__SECTION
+++ b/HDAs/import_Maya_nParticles_cache.hda/INDEX__SECTION
@@ -1,0 +1,14 @@
+Operator:     import_maya_nparticles_cache
+Label:        Import Maya nParticles Cache
+Path:         oplib:/Sop/import_maya_nparticles_cache?Sop/import_maya_nparticles_cache
+Icon:         SOP_subnet
+Table:        Sop
+License:      
+Extra:        inputcolors='0 ' outputcolors='1 "RGB 0.700195 0.700195 0.700195" ' 
+User:         
+Inputs:       0 to 0
+Subnet:       true
+Python:       false
+Empty:        false
+Modified:     Tue May 19 21:56:26 2026
+

--- a/HDAs/import_Maya_nParticles_cache.hda/Sections.list
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sections.list
@@ -1,0 +1,4 @@
+""
+INDEX__SECTION	INDEX_SECTION
+houdini.hdalibrary	houdini.hdalibrary
+Sop_1import__maya__nparticles__cache	Sop/import_maya_nparticles_cache

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.createtimes
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.createtimes
@@ -1,0 +1,5 @@
+{
+	"hdaroot/output0.def":1779198150,
+	"hdaroot.def":1779198870,
+	"hdaroot/python1.def":1779198441
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.houdini_versions
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.houdini_versions
@@ -1,0 +1,8 @@
+{
+	"values":["21.0.512"
+	],
+	"indexes":{
+		"hdaroot/output0.userdata":0,
+		"hdaroot/python1.userdata":0
+	}
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.mime
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.mime
@@ -1,0 +1,192 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY"
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="node_type"
+Content-Type: text/plain
+
+Sop
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot.init"
+Content-Type: text/plain
+
+type = import_maya_nparticles_cache
+matchesdef = 0
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot.def"
+Content-Type: text/plain
+
+sopflags sopflags =
+comment ""
+position -18.9635 1.86645
+connectornextid 0
+flags =  lock off model off template off footprint off xray off bypass off display on render on highlight off unload off savedata off compress on colordefault on exposed on
+outputsNamed3
+{
+}
+inputsNamed3
+{
+}
+inputs
+{
+}
+stat
+{
+  create -1
+  modify -1
+  author nobody
+  access 0777
+}
+color UT_Color RGB 0.8 0.8 0.8
+delscript ""
+exprlanguage hscript
+end
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot.userdata"
+Content-Type: text/plain
+
+{
+	"___Version___":{
+		"type":"string",
+		"value":""
+	}
+}
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/output0.init"
+Content-Type: text/plain
+
+type = output
+matchesdef = 1
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/output0.def"
+Content-Type: text/plain
+
+sopflags sopflags =
+comment ""
+position -1.11759e-08 2.8323
+connectornextid 1
+flags =  lock off model off template off footprint off xray off bypass off display on render on highlight off unload off savedata off compress on colordefault on exposed on
+outputsNamed3
+{
+}
+inputsNamed3
+{
+0 	python1 1 1 "input1"
+}
+inputs
+{
+0 	python1 0 1
+}
+stat
+{
+  create -1
+  modify -1
+  author nobody
+  access 0777
+}
+color UT_Color RGB 0.8 0.8 0.8
+delscript ""
+exprlanguage hscript
+end
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/output0.parm"
+Content-Type: text/plain
+
+{
+version 0.8
+outputidx	[ 0	locks=0 ]	(	0	)
+}
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/output0.userdata"
+Content-Type: text/plain
+
+{
+	"___Version___":{
+		"type":"string",
+		"value":"___EXTERNAL___"
+	}
+}
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/python1.init"
+Content-Type: text/plain
+
+type = python
+matchesdef = 1
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/python1.def"
+Content-Type: text/plain
+
+sopflags sopflags =
+comment ""
+position -1.11759e-08 4.53917
+connectornextid 0
+flags =  lock off model off template off footprint off xray off bypass off display off render off highlight off unload off savedata off compress on colordefault on exposed on
+outputsNamed3
+{
+1 "output1"
+}
+inputsNamed3
+{
+}
+inputs
+{
+}
+stat
+{
+  create -1
+  modify -1
+  author nobody
+  access 0777
+}
+color UT_Color RGB 0.8 0.8 0.8
+delscript ""
+exprlanguage hscript
+end
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/python1.parm"
+Content-Type: text/plain
+
+{
+version 0.8
+python	[ 0	locks=0 ]	(	"_parent = hou.pwd().parent()
+_parent.hdaModule().load(_parent, hou.pwd().geometry(), hou.frame())
+"	)
+maintainstate	[ 0	locks=0 ]	(	"off"	)
+}
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot/python1.userdata"
+Content-Type: text/plain
+
+{
+	"___Version___":{
+		"type":"string",
+		"value":"___EXTERNAL___"
+	}
+}
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot.order"
+Content-Type: text/plain
+
+2
+output0
+python1
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY
+Content-Disposition: attachment; filename="hdaroot.net"
+Content-Type: text/plain
+
+1
+
+--HOUDINIMIMEBOUNDARY0xD3ADD339-0x00000F49-0x56B122C9-0x00000001HOUDINIMIMEBOUNDARY--

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.modtimes
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Contents.modtimes
@@ -1,0 +1,5 @@
+{
+	"hdaroot/output0.def":1779198442,
+	"hdaroot.def":1779198985,
+	"hdaroot/python1.def":1779198960
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Sections.list
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Contents.dir/Sections.list
@@ -1,0 +1,2 @@
+""
+Contents.mime	Contents.mime

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/CreateScript
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/CreateScript
@@ -1,0 +1,14 @@
+# Automatically generated script
+\set noalias = 1
+#
+#  Creation script for inport_maya_nparticle_cache operator
+#
+
+if ( "$arg1" == "" ) then
+    echo This script is intended as a creation script
+    exit
+endif
+
+# Node $arg1 (Sop/inport_maya_nparticle_cache)
+opexprlanguage -s hscript $arg1
+opuserdata -n '___Version___' -v '' $arg1

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/DialogScript
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/DialogScript
@@ -1,0 +1,27 @@
+# Dialog script for inport_maya_nparticle_cache automatically generated
+
+{
+    name	import_maya_nparticles_cache
+    script	import_maya_nparticles_cache
+    label	"Import Maya nParticles Cache"
+
+    help {
+	""
+    }
+
+    parm {
+        name    "python_module_path"
+        label   "Python Module Path"
+        type    file
+        default { "" }
+        parmtag { "script_callback_language" "python" }
+    }
+    parm {
+        name    "nParticle_cache_file_path"
+        label   "nParticle Cache File"
+        type    file
+        default { "" }
+        parmtag { "filechooser_mode" "read" }
+        parmtag { "script_callback_language" "python" }
+    }
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/ExtraFileOptions
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/ExtraFileOptions
@@ -1,0 +1,22 @@
+{
+	"PythonModule/Cursor":{
+		"type":"intarray",
+		"value":[1,1]
+	},
+	"PythonModule/IsExpr":{
+		"type":"bool",
+		"value":false
+	},
+	"PythonModule/IsPython":{
+		"type":"bool",
+		"value":true
+	},
+	"PythonModule/IsScript":{
+		"type":"bool",
+		"value":true
+	},
+	"PythonModule/Source":{
+		"type":"string",
+		"value":""
+	}
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Help
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Help
@@ -1,0 +1,47 @@
+= Import Maya nParticles Cache =
+
+Reads a Maya nParticles cache (`.mc` / `.mcx`) frame by frame and reconstructs
+the particle geometry as Houdini points.
+
+== Parameters ==
+
+Python Module Path:
+    Path to `nCache.py`. This file is loaded on every cook.
+
+nParticle Cache File:
+    Path to the Maya cache XML descriptor (e.g. `particleShape.xml`).
+    The `.mc` / `.mcx` data files must be in the same directory.
+
+== Attributes ==
+
+The following point attributes are created if the corresponding channel is
+present in the cache:
+
+table>>
+    tr>>
+        th>> Attribute
+        th>> Type
+        th>> Description
+    tr>>
+        td>> `P`
+        td>> vector
+        td>> Point positions (from `position` channel).
+    tr>>
+        td>> `id`
+        td>> int
+        td>> Stable particle IDs across frames.
+    tr>>
+        td>> *(others)*
+        td>> float / vector
+        td>> All other scalar and vector channels present in the cache.
+
+Channels whose array length does not match the particle count at the current
+frame are silently skipped.
+
+== Notes ==
+
+* The node must be connected to a cache exported by Maya's nParticles
+  (Nucleus solver), not the legacy Maya Particle system.
+* One cook per frame change: the cache file is read on every frame.
+  For interactive playback over a network path, consider pre-caching
+  the frames to a local disk with a File Cache SOP.

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Help
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Help
@@ -1,7 +1,6 @@
 = Import Maya nParticles Cache =
 
-Reads a Maya nParticles cache (`.mc` / `.mcx`) frame by frame and reconstructs
-the particle geometry as Houdini points.
+"""Reads a Maya nParticles cache (.mc / .mcx) frame by frame and reconstructs the particle geometry as Houdini points."""
 
 == Parameters ==
 
@@ -40,8 +39,8 @@ frame are silently skipped.
 
 == Notes ==
 
-* The node must be connected to a cache exported by Maya's nParticles
-  (Nucleus solver), not the legacy Maya Particle system.
+* This node reads caches exported by Maya's nParticles (Nucleus solver),
+  not the legacy Maya Particle system.
 * One cook per frame change: the cache file is read on every frame.
   For interactive playback over a network path, consider pre-caching
   the frames to a local disk with a File Cache SOP.

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/InternalFileOptions
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/InternalFileOptions
@@ -1,0 +1,10 @@
+{
+	"nodeconntype":{
+		"type":"bool",
+		"value":false
+	},
+	"nodeparmtype":{
+		"type":"bool",
+		"value":false
+	}
+}

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/PythonModule
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/PythonModule
@@ -9,7 +9,7 @@ def _load_module(node):
     if not path or not os.path.isfile(path):
         raise hou.NodeError("Python Module Path is not set or file not found: %s" % path)
     spec = importlib.util.spec_from_file_location('nCache', path)
-    if spec is None:
+    if spec is None or spec.loader is None:
         raise hou.NodeError("Failed to create module spec from: %s" % path)
     nc = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(nc)
@@ -35,8 +35,9 @@ def load(node, geo, frame):
 
     try:
         id_array = mc.getAttrValues('id')
-        geo.addAttrib(hou.attribType.Point, 'id', default_value=0)
-        geo.setPointIntAttribValuesFromString('id', id_array.astype(np.int32).tobytes())
+        if len(id_array) == n_points:
+            geo.addAttrib(hou.attribType.Point, 'id', default_value=0)
+            geo.setPointIntAttribValuesFromString('id', id_array.astype(np.int32).tobytes())
     except (ValueError, IndexError):
         pass
 

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/PythonModule
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/PythonModule
@@ -1,0 +1,57 @@
+import importlib.util
+import os
+import hou
+import numpy as np
+
+
+def _load_module(node):
+    path = node.parm('python_module_path').eval()
+    if not path or not os.path.isfile(path):
+        raise hou.NodeError("Python Module Path is not set or file not found: %s" % path)
+    spec = importlib.util.spec_from_file_location('nCache', path)
+    if spec is None:
+        raise hou.NodeError("Failed to create module spec from: %s" % path)
+    nc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(nc)
+    return nc
+
+
+def load(node, geo, frame):
+    nc = _load_module(node)
+
+    xml_path = node.parm('nParticle_cache_file_path').eval()
+    mc = nc.NPCacheMC(xml_path)
+    mc.setFrame(frame)
+    if not mc.read():
+        return
+
+    try:
+        pos_array = mc.getAttrValues('position')
+    except (ValueError, IndexError) as e:
+        raise hou.NodeError("'position' channel not found in cache: %s" % e)
+
+    geo.createPoints(pos_array.tolist())
+    n_points = len(pos_array)
+
+    try:
+        id_array = mc.getAttrValues('id')
+        geo.addAttrib(hou.attribType.Point, 'id', default_value=0)
+        geo.setPointIntAttribValuesFromString('id', id_array.astype(np.int32).tobytes())
+    except (ValueError, IndexError):
+        pass
+
+    for attr in mc.getAttrs():
+        if attr in ('id', 'position', 'count'):
+            continue
+        try:
+            values = mc.getAttrValues(attr)
+        except (ValueError, IndexError):
+            continue
+        if len(values) != n_points or len(values) == 0:
+            continue
+        if values[0].size == 1:
+            geo.addAttrib(hou.attribType.Point, attr, default_value=0.0)
+            geo.setPointFloatAttribValuesFromString(attr, values.astype(np.float32).tobytes())
+        elif values[0].size == 3:
+            geo.addAttrib(hou.attribType.Point, attr, default_value=(0.0, 0.0, 0.0))
+            geo.setPointFloatAttribValuesFromString(attr, values.astype(np.float32).tobytes())

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Sections.list
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Sections.list
@@ -1,0 +1,10 @@
+""
+DialogScript	DialogScript
+CreateScript	CreateScript
+InternalFileOptions	InternalFileOptions
+Contents.gz	Contents.gz
+TypePropertiesOptions	TypePropertiesOptions
+Help	Help
+Tools.shelf	Tools.shelf
+PythonModule	PythonModule
+ExtraFileOptions	ExtraFileOptions

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Tools.shelf
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/Tools.shelf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shelfDocument>
+  <!-- This file contains definitions of shelves, toolbars, and tools.
+ It should not be hand-edited when it is being used by the application.
+ Note, that two definitions of the same element are not allowed in
+ a single file. -->
+
+  <tool name="$HDA_DEFAULT_TOOL" label="$HDA_LABEL" icon="$HDA_ICON">
+    <toolMenuContext name="viewer">
+      <contextNetType>SOP</contextNetType>
+    </toolMenuContext>
+    <toolMenuContext name="network">
+      <contextOpType>$HDA_TABLE_AND_NAME</contextOpType>
+    </toolMenuContext>
+    <toolSubmenu>CHD</toolSubmenu>
+    <script scriptType="python"><![CDATA[import soptoolutils
+
+soptoolutils.genericTool(kwargs, '$HDA_NAME')]]></script>
+  </tool>
+</shelfDocument>

--- a/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/TypePropertiesOptions
+++ b/HDAs/import_Maya_nParticles_cache.hda/Sop_1import__maya__nparticles__cache/TypePropertiesOptions
@@ -1,0 +1,14 @@
+CheckExternal := 1;
+ContentsCompressionType := 1;
+ForbidOutsideParms := 1;
+GzipContents := 1;
+LockContents := 1;
+MakeDefault := 1;
+ParmsFromVfl := 0;
+PrefixDroppedParmLabel := 0;
+PrefixDroppedParmName := 0;
+SaveCachedCode := 0;
+SaveIcon := 1;
+SaveSpareParms := 0;
+UnlockOnCreate := 0;
+UseDSParms := 1;


### PR DESCRIPTION
## Summary

- Track `import_Maya_nParticles_cache.hda` in git (was previously excluded by `*.hda` gitignore rule)
- Fix vector attribute data corruption: `DoubleVectorArray` channels were passed as float64 bytes; now cast to float32 before `setPointFloatAttribValuesFromString`
- Add error handling for missing `position` / `id` channels
- Replace fragile `count` channel assumption with `len(pos_array)`
- Move all logic from Python SOP parm to HDA PythonModule — consistent with export HDAs, easier to review and maintain
- Remove unused `sys` and `threading` imports
- Fix op type name typo: `inport_maya_nparticle_cache` → `import_maya_nparticles_cache`
- Add Help card documentation
- Update `HDAs/README.md` with import HDA section

## Test plan

- [ ] Load HDA on a fresh clone — confirm node appears as `import_maya_nparticles_cache`
- [ ] Connect a valid nParticles `.xml` path and scrub through frames — confirm points appear with correct attributes
- [ ] Test with a cache that has `DoubleVectorArray` channels (e.g. `velocity`) — confirm values are not corrupted
- [ ] Test frame with no matching `.mc` file — confirm geometry stays empty without error
- [ ] Test with missing `position` channel — confirm a clear `NodeError` is raised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Maya nParticles cache import asset that reads nParticle caches frame-by-frame and reconstructs particle geometry in Houdini, importing position, id (when available), and other particle attributes.

* **Documentation**
  * Updated docs to reflect import + export capabilities and added detailed help, parameters, attribute behavior, and per-frame/caching guidance.

* **Chores**
  * Version control updated to include import cache artifacts and added a shelf tool for quick access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chordee/mayaGeoCache/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->